### PR TITLE
chore(deps): oppgrader com.expediagroup.graphql (plugin + client) til v10.2.2

### DIFF
--- a/person/build.gradle.kts
+++ b/person/build.gradle.kts
@@ -4,7 +4,7 @@ import com.expediagroup.graphql.plugin.gradle.graphql
 plugins {
     id("common")
     `java-library`
-    id("com.expediagroup.graphql") version "8.9.1"
+    id("com.expediagroup.graphql") version "10.2.2"
     kotlin("plugin.serialization") version "2.4.10"
 }
 
@@ -13,7 +13,7 @@ dependencies {
     implementation(libs.bundles.ktor.client)
     implementation("io.ktor:ktor-serialization-kotlinx-json:${libs.versions.ktor.get()}")
 
-    implementation("com.expediagroup", "graphql-kotlin-ktor-client", "8.9.1")
+    implementation("com.expediagroup", "graphql-kotlin-ktor-client", "10.2.2")
     implementation("com.nimbusds:oauth2-oidc-sdk:11.38.2")
 
     testImplementation("no.nav.security:mock-oauth2-server:6.0.2")


### PR DESCRIPTION
Koordinert oppgradering av `com.expediagroup.graphql`-pluginet og `graphql-kotlin-ktor-client`-avhengigheten til samme versjon (10.2.2), for å unngå versjonsskjevhet mellom kodegenerator og runtime.

Erstatter/kombinerer #384 (plugin) og #381 (client), som hver for seg ville gitt en usynkronisert oppgradering.

Verifisert lokalt med full clean build + `:person:test` og root `:test`. `PdlPersonsBeskyttelseInfoRepositoryTest` dekker den genererte PDL-klienten mot en ekte GraphQL-respons via WireMock (suksess, feil, alle adressebeskyttelsesgraderinger), så testdekningen er god nok til å stole på denne oppgraderingen.

Closes #384, closes #381.