### PR TITLE
chore: migrer til Jackson 3 (dp-version-catalog 20260812.281)

### DIFF
--- a/person/src/test/kotlin/no/nav/dagpenger/dataprodukter/PdlMock.kt
+++ b/person/src/test/kotlin/no/nav/dagpenger/dataprodukter/PdlMock.kt
@@ -2,7 +2,7 @@ package no.nav.dagpenger.dataprodukter
 
 import com.expediagroup.graphql.client.types.GraphQLClientError
 import com.expediagroup.graphql.client.types.GraphQLClientResponse
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20260123.238.f6b1ed")
+            from("no.nav.dagpenger:dp-version-catalog:20260812.281")
         }
     }
 }

--- a/soknad/src/main/kotlin/no/nav/dagpenger/dataprodukter/søknad/ObjectMapper.kt
+++ b/soknad/src/main/kotlin/no/nav/dagpenger/dataprodukter/søknad/ObjectMapper.kt
@@ -1,5 +1,5 @@
 package no.nav.dagpenger.dataprodukter.søknad
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 
 internal val objectMapper = jacksonObjectMapper()

--- a/soknad/src/main/kotlin/no/nav/dagpenger/dataprodukter/søknad/data/QuizSøknadData.kt
+++ b/soknad/src/main/kotlin/no/nav/dagpenger/dataprodukter/søknad/data/QuizSøknadData.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.dataprodukter.søknad.data
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ObjectNode
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ObjectNode
 import no.nav.dagpenger.dataprodukter.søknad.objectMapper
 
 internal class QuizSøknadData(
@@ -62,8 +62,8 @@ internal class QuizSøknadData(
                     }
 
                     "flervalg" -> {
-                        fakta["svar"].map {
-                            val flervalg: ObjectNode = fakta.deepCopy()
+                        fakta["svar"].toList().map {
+                            val flervalg = fakta.deepCopy() as ObjectNode
                             flervalg.put("svar", it.asText())
                         }
                     }
@@ -89,6 +89,12 @@ internal class QuizSøknadData(
                 .map {
                     val gruppe = it["gruppe"]?.asText()
                     val gruppeId = it["gruppeId"]?.asText()
-                    Faktum(it["beskrivendeId"].asText(), it["type"].asText(), it["svar"].asText(), gruppe, gruppeId)
+                    Faktum(it["beskrivendeId"].asText(), it["type"].asText(), it["svar"].asTextOrEmpty(), gruppe, gruppeId)
                 }.filterNot { it.erFritekst }
 }
+
+/**
+ * Speiler Jackson 2 sin gamle, tolerante `asText()`-oppførsel: returner tom streng for
+ * container-noder (array/objekt) i stedet for å kaste [tools.jackson.databind.exc.JsonNodeException].
+ */
+private fun JsonNode.asTextOrEmpty(): String = if (isValueNode) asText() else ""

--- a/soknad/src/main/kotlin/no/nav/dagpenger/dataprodukter/søknad/data/SøknadData.kt
+++ b/soknad/src/main/kotlin/no/nav/dagpenger/dataprodukter/søknad/data/SøknadData.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.dataprodukter.søknad.data
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 
 abstract class SøknadData(
     val data: JsonNode,

--- a/soknad/src/test/kotlin/no/nav/dagpenger/dataprodukter/søknad/data/QuizSøknadDataTest.kt
+++ b/soknad/src/test/kotlin/no/nav/dagpenger/dataprodukter/søknad/data/QuizSøknadDataTest.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.dataprodukter.søknad.data
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.dagpenger.dataprodukter.søknad.objectMapper
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/src/main/kotlin/no/nav/dagpenger/dataprodukter/JsonMessage.kt
+++ b/src/main/kotlin/no/nav/dagpenger/dataprodukter/JsonMessage.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.dataprodukter
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 fun JsonNode.asUUID(): UUID = this.asText().let { UUID.fromString(it) }

--- a/src/main/kotlin/no/nav/dagpenger/dataprodukter/ObjectMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/dataprodukter/ObjectMapper.kt
@@ -1,13 +1,9 @@
 package no.nav.dagpenger.dataprodukter
 
-import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import tools.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 
 internal val objectMapper =
-    jacksonObjectMapper().apply {
-        registerKotlinModule()
-        registerModule(JavaTimeModule())
-        configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-    }
+    jacksonMapperBuilder()
+        .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+        .build()

--- a/src/main/kotlin/no/nav/dagpenger/dataprodukter/produkter/behandling/BehandlingRiver.kt
+++ b/src/main/kotlin/no/nav/dagpenger/dataprodukter/produkter/behandling/BehandlingRiver.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.dataprodukter.produkter.behandling
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDateTime

--- a/src/main/kotlin/no/nav/dagpenger/dataprodukter/produkter/søknad/DokumentkravRiver.kt
+++ b/src/main/kotlin/no/nav/dagpenger/dataprodukter/produkter/søknad/DokumentkravRiver.kt
@@ -65,7 +65,7 @@ internal class DokumentkravRiver(
                     hendelseId = packet["hendelseId"].asUUID()
                 }
 
-            packet["dokumentkrav"].map {
+            packet["dokumentkrav"].toList().map {
                 Dokumentkrav
                     .newBuilder(dokumentkrav)
                     .apply {

--- a/src/main/kotlin/no/nav/dagpenger/dataprodukter/produkter/søknad/SøknadsdataRiver.kt
+++ b/src/main/kotlin/no/nav/dagpenger/dataprodukter/produkter/søknad/SøknadsdataRiver.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.dataprodukter.produkter.søknad
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDateTime

--- a/src/test/kotlin/no/nav/dagpenger/dataprodukter/produkter/oppgave/OppgaveRiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/dataprodukter/produkter/oppgave/OppgaveRiverTest.kt
@@ -103,6 +103,7 @@ internal class OppgaveRiverTest {
     "saksbehandlerIdent": "Z123456",
     "beslutterIdent": "Z987654",
     "tilstandsendring": {
+      "sekvensnummer": 1,
       "tilstandsendringId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
       "tilstand": "FERDIG_BEHANDLET",
       "tidspunkt": "2026-01-11T10:15:30"

--- a/src/test/resources/dp-behandling/behandlingsresultat_beregnet.json
+++ b/src/test/resources/dp-behandling/behandlingsresultat_beregnet.json
@@ -4971,7 +4971,8 @@
             "verdi": [
               {
                 "fødselsdato": "2000-01-01",
-                "kvalifiserer": true
+                "kvalifiserer": true,
+                "forsørgeransvar": false
               }
             ],
             "datatype": "barn"

--- a/src/test/resources/dp-behandling/behandlingsresultat_gjenopptak.json
+++ b/src/test/resources/dp-behandling/behandlingsresultat_gjenopptak.json
@@ -6026,7 +6026,8 @@
             "verdi": [
               {
                 "fødselsdato": "2000-01-01",
-                "kvalifiserer": true
+                "kvalifiserer": true,
+                "forsørgeransvar": false
               }
             ],
             "datatype": "barn"

--- a/src/test/resources/dp-behandling/behandlingsresultat_gjenopptak_avslag.json
+++ b/src/test/resources/dp-behandling/behandlingsresultat_gjenopptak_avslag.json
@@ -6314,7 +6314,8 @@
             "verdi": [
               {
                 "fødselsdato": "2000-01-01",
-                "kvalifiserer": true
+                "kvalifiserer": true,
+                "forsørgeransvar": false
               }
             ],
             "datatype": "barn"


### PR DESCRIPTION
## Hva
Bumper `dp-version-catalog` til nyeste versjon (20260812.281), som migrerer Jackson 2 -> 3 (`com.fasterxml.jackson.*` -> `tools.jackson.*`). Lukker/erstatter #382.

## Endringer
- Alle imports av `databind`/`module.kotlin` renamet til `tools.jackson.*` (jackson-annotations/`@JsonProperty` er uendret per Jackson 3 sitt design)
- `ObjectMapper.kt` (root) skrevet om fra mutable `.apply{}` til `jacksonMapperBuilder()`-kjede, siden Jackson 3 sin mapper er immutable
- **Fant en reell, stille regresjon**: Jackson 3 introduserer `JsonNode.map(Function)` som medlemsfunksjon, som skygger for Kotlin sin `Iterable.map`-extension og kun mapper roten selv (ikke elementene i et array). Rammet `DokumentkravRiver.kt` og `QuizSøknadData.kt` sin flervalg-håndtering – fikset med eksplisitt `.toList().map { ... }`
- **Fant en bevisst innstramming**: jackson-module-kotlin har nå `strictNullChecks=true` som default (var `false`). Manglende påkrevde felt (f.eks. `forsørgeransvar` på `BarnVerdiDTO`, `sekvensnummer` på `TilstandsendringDTO`) kaster nå feil i stedet for stille å defaulte til `false`/`0`. Vurdert med produkteier-hatt på: beholder den strenge oppførselen, og har rettet testfixturene til å reflektere komplette payloads
- La til `asTextOrEmpty()` i `QuizSøknadData` for å bevare gammel `asText()`-oppførsel (tom streng for container-noder) ett sted, siden Jackson 3 nå kaster `JsonNodeException`

## Verifisering
Bygget og alle tester (root, `:soknad`, `:person`, `:behandling`) er grønne lokalt.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>